### PR TITLE
Don't silently ignore PostageApp rejections

### DIFF
--- a/templated_email/backends/postageapp_backend.py
+++ b/templated_email/backends/postageapp_backend.py
@@ -7,6 +7,9 @@ from postageapp import PostageApp
 
 from . import HeaderNotSupportedException
 
+class PostageAppException(Exception):
+    pass
+
 class TemplateBackend:
     """
     Backend which uses PostageApp to send templated emails
@@ -39,6 +42,8 @@ class TemplateBackend:
                 variables=context,
                 headers=headers
             )
+            if not result:
+                raise PostageAppException( self.conn.error )
         except Exception, e:
             if not fail_silently:
                 raise


### PR DESCRIPTION
Hi Brad,

Thanks for python-postageapp and django-templated-email.  I wondered if you'd accept this patch to propagate PostageApp rejections as exceptions.  Although it's possible to check the success/fail of the message send by return value without it, there did not seem to be an existing way to access the error string.

Dan
