### PR TITLE
Add functionality to return a templated EmailMessage instance without sending.

### DIFF
--- a/templated_email/__init__.py
+++ b/templated_email/__init__.py
@@ -2,7 +2,8 @@ from django.conf import settings
 from django.utils.importlib import import_module
 from django.core.exceptions import ImproperlyConfigured
 
-def get_connection(backend=None, template_prefix=None, fail_silently=False, **kwargs):
+def get_connection(backend=None, template_prefix=None,
+                   fail_silently=False, **kwargs):
     """Load a templated e-mail backend and return an instance of it.
 
     If backend is None (default) settings.TEMPLATED_EMAIL_BACKEND is used.
@@ -23,21 +24,26 @@ def get_connection(backend=None, template_prefix=None, fail_silently=False, **kw
             mod_name, klass_name = path.rsplit('.', 1)
             mod = import_module(mod_name)
         except ImportError, e:
-            raise ImproperlyConfigured(('Error importing templated email backend module %s: "%s"'
-                                    % (mod_name, e)))
+            raise ImproperlyConfigured(
+                ('Error importing templated email backend module %s: "%s"'
+                 % (mod_name, e)))
     try:
         klass = getattr(mod, klass_name)
     except AttributeError:
         raise ImproperlyConfigured(('Module "%s" does not define a '
                                     '"%s" class' % (mod_name, klass_name)))
-    return klass(fail_silently=fail_silently, template_prefix=template_prefix, **kwargs)
+    return klass(fail_silently=fail_silently, template_prefix=template_prefix,
+                 **kwargs)
 
 
-def send_templated_mail(template_name, from_email, recipient_list, context, cc=[], bcc=[], fail_silently=False, connection=None, headers = {}, **kwargs):
-    """Easy wrapper for sending a templated email to a recipient list. 
+def send_templated_mail(template_name, from_email, recipient_list, context,
+                        cc=[], bcc=[], fail_silently=False, connection=None,
+                        headers = {}, **kwargs):
+    """Easy wrapper for sending a templated email to a recipient list.
 
     Final behaviour of sending depends on the currently selected engine.
     See BackendClass.send.__doc__
-    """ 
+    """
     connection = connection or get_connection()
-    return connection.send(template_name, from_email, recipient_list, context, cc, bcc, fail_silently, headers=headers, **kwargs)
+    return connection.send(template_name, from_email, recipient_list, context,
+                           cc, bcc, fail_silently, headers=headers, **kwargs)


### PR DESCRIPTION
This adds functionality to return a templatized EmailMessage instance in the vanilla_django backend only for now. This is useful for saving messages for deferred sending to not block on the request. This will allow integration with django-mailer: https://github.com/pinax/django-mailer

There were some style fixes for PEP8.
