### PR TITLE
Refactor for get_email_message() / get_templated_mail()

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,33 @@
+*.py[cod]
+
+# C extensions
+*.so
+
+# Packages
+*.egg
+*.egg-info
+dist
+build
+eggs
+parts
+bin
+var
+sdist
+develop-eggs
+.installed.cfg
+lib
+lib64
+
+# Installer logs
+pip-log.txt
+
+# Unit test / coverage reports
+.coverage
+.tox
+nosetests.xml
+
+#Translations
+*.mo
+
+#Mr Developer
+.mr.developer.cfg

--- a/templated_email/__init__.py
+++ b/templated_email/__init__.py
@@ -1,8 +1,10 @@
 from django.conf import settings
 from django.utils.importlib import import_module
 from django.core.exceptions import ImproperlyConfigured
+from templated_email.backends.vanilla_django import TemplateBackend
 
-def get_connection(backend=None, template_prefix=None, fail_silently=False, **kwargs):
+def get_connection(backend=None, template_prefix=None,
+                   fail_silently=False, **kwargs):
     """Load a templated e-mail backend and return an instance of it.
 
     If backend is None (default) settings.TEMPLATED_EMAIL_BACKEND is used.
@@ -11,7 +13,6 @@ def get_connection(backend=None, template_prefix=None, fail_silently=False, **kw
     constructor of the backend.
     """
     # This method is mostly a copy of the backend loader present in django.core.mail.get_connection
-    template_prefix = template_prefix or getattr(settings,'TEMPLATED_EMAIL_TEMPLATE_DIR','templated_email/')
     path = backend or getattr(settings,'TEMPLATED_EMAIL_BACKEND','templated_email.backends.vanilla_django.TemplateBackend')
     try:
         # First check if class name is omited and we have module in settings
@@ -23,21 +24,40 @@ def get_connection(backend=None, template_prefix=None, fail_silently=False, **kw
             mod_name, klass_name = path.rsplit('.', 1)
             mod = import_module(mod_name)
         except ImportError, e:
-            raise ImproperlyConfigured(('Error importing templated email backend module %s: "%s"'
-                                    % (mod_name, e)))
+            raise ImproperlyConfigured(
+                ('Error importing templated email backend module %s: "%s"'
+                 % (mod_name, e)))
     try:
         klass = getattr(mod, klass_name)
     except AttributeError:
         raise ImproperlyConfigured(('Module "%s" does not define a '
                                     '"%s" class' % (mod_name, klass_name)))
-    return klass(fail_silently=fail_silently, template_prefix=template_prefix, **kwargs)
+    return klass(fail_silently=fail_silently, template_prefix=template_prefix,
+                 **kwargs)
 
 
-def send_templated_mail(template_name, from_email, recipient_list, context, cc=[], bcc=[], fail_silently=False, connection=None, headers = {}, **kwargs):
-    """Easy wrapper for sending a templated email to a recipient list. 
+def get_templated_mail(template_name, context, from_email=None, to=None,
+                       cc=None, bcc=None, headers=None, template_prefix=None,
+                       template_dir=None):
+    """Returns a templated EmailMessage instance without a connection using
+    the django templating backend."""
+    templater = TemplateBackend(template_prefix=template_prefix)
+    return templater.get_email_message(template_name, context,
+                                       from_email=from_email, to=to,
+                                       cc=cc, bcc=bcc, headers=headers,
+                                       template_prefix=template_prefix,
+                                       template_dir=template_dir)
+
+
+def send_templated_mail(template_name, from_email, recipient_list, context,
+                        cc=None, bcc=None, fail_silently=False, connection=None,
+                        headers=None, template_dir=None, **kwargs):
+    """Easy wrapper for sending a templated email to a recipient list.
 
     Final behaviour of sending depends on the currently selected engine.
     See BackendClass.send.__doc__
-    """ 
+    """
     connection = connection or get_connection()
-    return connection.send(template_name, from_email, recipient_list, context, cc, bcc, fail_silently, headers=headers, **kwargs)
+    return connection.send(template_name, from_email, recipient_list, context,
+                           cc=cc, bcc=bcc, fail_silently=fail_silently,
+                           headers=headers, template_dir=template_dir, **kwargs)

--- a/templated_email/backends/mailchimp_sts.py
+++ b/templated_email/backends/mailchimp_sts.py
@@ -3,27 +3,25 @@ from greatape import MailChimpSTS
 from django.conf import settings
 from django.utils.translation import ugettext as _
 
+
 class TemplateBackend(vanilla_django.TemplateBackend):
     def __init__(self, *args, **kwargs):
         vanilla_django.TemplateBackend.__init__(self, *args, **kwargs)
         self.connection = MailChimpSTS(settings.MAILCHIMP_API_KEY, debug=True)
-        
-    def send(self, template_name, from_email, recipient_list, context, 
-                cc=[], bcc=[], 
-                fail_silently=False, 
-                headers={}, 
-                template_dir=None, file_extension=None,
-                **kwargs):
+
+    def send(self, template_name, from_email, recipient_list, context,
+                cc=None, bcc=None, fail_silently=False, headers=None,
+                template_dir=None, file_extension=None, **kwargs):
         config = getattr(settings,'TEMPLATED_EMAIL_MAILCHIMP',{}).get(template_name,{})
         parts = self._render_email(template_name, context, template_dir, file_extension)
         params={
             'message':{
-                'subject':config.get('subject',_('%s email subject' % template_name)) % context,
-                'html':parts.get('html',''),
-                'text':parts.get('plain',''),
-                'from_name':' '.join(from_email.split(' ')[:-1]) or 'Nobody',
-                'from_email':from_email,
-                'to_email':recipient_list,
+                'subject': config.get('subject',_('%s email subject' % template_name)) % context,
+                'html': parts.get('html',''),
+                'text': parts.get('plain',''),
+                'from_name': ' '.join(from_email.split(' ')[:-1]) or 'Nobody',
+                'from_email': from_email,
+                'to_email': recipient_list,
             },
             'track_opens':config.get('track_opens',False),
             'track_clicks':config.get('track_clicks',False),

--- a/templated_email/backends/postageapp_backend.py
+++ b/templated_email/backends/postageapp_backend.py
@@ -1,16 +1,15 @@
 from django.conf import settings
 from django.core.exceptions import ImproperlyConfigured
-from django.core.mail import send_mail, EmailMessage, EmailMultiAlternatives
-from django.utils.translation import ugettext as _
 
 from postageapp import PostageApp
-
 from . import HeaderNotSupportedException
+
 
 class PostageAppException(Exception):
     pass
 
-class TemplateBackend:
+
+class TemplateBackend(object):
     """
     Backend which uses PostageApp to send templated emails
 
@@ -29,10 +28,11 @@ class TemplateBackend:
         if api_key:
             self.conn = PostageApp(api_key)
         else:
-            raise ImproperlyConfigured('You need to provide POSTAGEAPP_API_KEY or EMAIL_POSTAGEAPP_API_KEY in your Django settings file') 
+            raise ImproperlyConfigured('You need to provide POSTAGEAPP_API_KEY or EMAIL_POSTAGEAPP_API_KEY in your Django settings file')
 
-    def send(self, template_name, from_email, recipient_list, context, cc=[], bcc=[], fail_silently=False, headers={}, **kwargs):
-        if cc != [] or bcc != []:
+    def send(self, template_name, from_email, recipient_list, context,
+             cc=None, bcc=None, fail_silently=False, headers=None, **kwargs):
+        if cc or bcc:
             raise HeaderNotSupportedException("PostageApp doesn't currently support CC, or BCC")
         try:
             result = self.conn.send_message(
@@ -44,7 +44,7 @@ class TemplateBackend:
             )
             if not result:
                 raise PostageAppException( self.conn.error )
-        except Exception, e:
+        except Exception:
             if not fail_silently:
                 raise
 


### PR DESCRIPTION
This is a refactor after the discussion in #16. 

Lots of fixes for more standards compliance.
- Default function arguments changed to None instead of mutable types.
- Add get_email_message() for returning EmailMessage instances.
- Some fixes for PEP8, although not entirely PEP8 compliant yet.

`get_email_message()`  and `get_templated_mail()` have different function signatures to be closer to django's `EmailMessage`.
