### PR TITLE
Strip whitespace out of email subject

### DIFF
--- a/templated_email/backends/vanilla_django.py
+++ b/templated_email/backends/vanilla_django.py
@@ -103,7 +103,7 @@ class TemplateBackend(object):
 
         for part in ['subject', 'html', 'plain']:
             try:
-                response[part] = render_block_to_string(full_template_names, part, render_context)
+                response[part] = render_block_to_string(full_template_names, part, render_context).strip()
             except BlockNotFound as error:
                 errors[part] = error
 


### PR DESCRIPTION
Templates often add a lots of whitespace around content.
While this is not a thing for web browsers, email client shows
whitespace in subject. Keeping template clean of whitespace is not an
option since most of IDE would like to reformat template with
indentation.