### PR TITLE
Auto-escape only the HTML part

### DIFF
--- a/templated_email/backends/vanilla_django.py
+++ b/templated_email/backends/vanilla_django.py
@@ -82,7 +82,6 @@ class TemplateBackend(object):
                       template_dir=None, file_extension=None):
         response = {}
         errors = {}
-        render_context = Context(context, autoescape=False)
 
         file_extension = file_extension or self.template_suffix
         if file_extension.startswith('.'):
@@ -102,6 +101,7 @@ class TemplateBackend(object):
             full_template_names.append(one_full_template_name)
 
         for part in ['subject', 'html', 'plain']:
+            render_context = Context(context, autoescape=(part == 'html'))
             try:
                 response[part] = render_block_to_string(full_template_names, part, render_context)
             except BlockNotFound as error:

--- a/tox-requirements.txt
+++ b/tox-requirements.txt
@@ -1,6 +1,6 @@
 django-anymail==3.0
 django-pytest==0.2.0
-django-render-block==0.5
+django-render-block==0.8
 html2text==2016.5.29
 mock==2.0.0
 pytest==4.1.0


### PR DESCRIPTION
This PR enables auto-escaping on the HTML part but not on the plain text and subject parts.
It fixes #108, fixes #109, and closes #111 with a simpler alternative that doesn't rely on `html.parser`.

It relies on https://github.com/clokep/django-render-block/pull/21, that's why I bumped the requirement to `django-render-block==0.8`.
