### PR TITLE
Add django main version to tox tests in preparation for nightly tests

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -1,7 +1,8 @@
 [tox]
 envlist =
     py36-{flake8},
-    {py36,py37,py38,py39}-django{22,31,32}
+    {py36,py37,py38,py39}-django{22,31,32},
+    {py38,py39}-djangomain,
 
 
 [testenv]
@@ -13,8 +14,13 @@ deps=
     django22: Django==2.2
     django31: Django==3.1
     django32: Django==3.2
+    djangomain: https://github.com/django/django/archive/main.tar.gz
 
 [testenv:py36-flake8]
 commands = flake8 templated_email tests --ignore=E501
 deps =
     flake8
+
+
+[testenv:{py38,py39}-djangomain]
+ignore_outcome = true

--- a/tox.ini
+++ b/tox.ini
@@ -20,7 +20,3 @@ deps=
 commands = flake8 templated_email tests --ignore=E501
 deps =
     flake8
-
-
-[testenv:{py38,py39}-djangomain]
-ignore_outcome = true


### PR DESCRIPTION
Needed to close #122

The job is already configured.