### PR TITLE
Allow empty from_email param

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -313,7 +313,7 @@ Attributes:
 **templated_email_send_on_failure** (default: False):
     This attribute tells django-templated-email to send an email if the form is invalid.
 
-**templated_email_from_email** (default: **settings.TEMPLATED_EMAIL_FROM_EMAIL**):
+**templated_email_from_email** (default: **settings.TEMPLATED_EMAIL_FROM_EMAIL**. If it's also not defined, falls back to **DEFAULT_FROM_EMAIL**):
     String containing the email to send the email from.
 
 Methods:

--- a/README.rst
+++ b/README.rst
@@ -396,6 +396,7 @@ For legacy purposes you can specify email subjects in your settings file (but, t
 
 Additionally you can call **send_templated_mail** and optionally override the following parameters::
 
+    from_email='your.email@com/'          # Override the email sender. Default: (default: **settings.TEMPLATED_EMAIL_FROM_EMAIL**. If it's also not defined, falls back to **DEFAULT_FROM_EMAIL**)
     template_prefix='your_template_dir/'  # Override where the method looks for email templates (alternatively, use template_dir)
     template_suffix='email'               # Override the file extension of the email templates (alternatively, use file_extension)
     cc=['fubar@example.com']              # Set a CC on the mail

--- a/templated_email/__init__.py
+++ b/templated_email/__init__.py
@@ -51,9 +51,9 @@ def get_templated_mail(template_name, context, from_email=None, to=None,
                                        create_link=create_link)
 
 
-def send_templated_mail(template_name, from_email, recipient_list, context,
-                        cc=None, bcc=None, fail_silently=False, connection=None,
-                        headers=None, template_prefix=None,
+def send_templated_mail(template_name, from_email=None, recipient_list=None,
+                        context=None, cc=None, bcc=None, fail_silently=False,
+                        connection=None, headers=None, template_prefix=None,
                         template_suffix=None,
                         create_link=False, **kwargs):
     """Easy wrapper for sending a templated email to a recipient list.

--- a/templated_email/backends/vanilla_django.py
+++ b/templated_email/backends/vanilla_django.py
@@ -113,7 +113,7 @@ class TemplateBackend(object):
 
         return response
 
-    def get_email_message(self, template_name, context, from_email=None, to=None,
+    def get_email_message(self, template_name, context=None, from_email=None, to=None,
                           cc=None, bcc=None, headers=None,
                           template_prefix=None, template_suffix=None,
                           template_dir=None, file_extension=None,

--- a/templated_email/backends/vanilla_django.py
+++ b/templated_email/backends/vanilla_django.py
@@ -119,7 +119,7 @@ class TemplateBackend(object):
                           template_dir=None, file_extension=None,
                           attachments=None, create_link=False):
 
-        from_email = from_email or settings.DEFAULT_FROM_EMAIL
+        from_email = from_email or getattr(settings, 'TEMPLATED_EMAIL_FROM_EMAIL', None) or settings.DEFAULT_FROM_EMAIL
 
         context = context or {}
 

--- a/templated_email/backends/vanilla_django.py
+++ b/templated_email/backends/vanilla_django.py
@@ -119,6 +119,10 @@ class TemplateBackend(object):
                           template_dir=None, file_extension=None,
                           attachments=None, create_link=False):
 
+        from_email = from_email or settings.DEFAULT_FROM_EMAIL
+
+        context = context or {}
+
         if create_link:
             email_uuid = uuid.uuid4()
             link_context = dict(context)
@@ -234,7 +238,7 @@ class TemplateBackend(object):
         parts['plain'] = plain_func(parts['html'])
         return True
 
-    def send(self, template_name, from_email, recipient_list, context,
+    def send(self, template_name, from_email=None, recipient_list=None, context=None,
              cc=None, bcc=None,
              fail_silently=False,
              headers=None,

--- a/tests/backends/test_vanilla_django_backend.py
+++ b/tests/backends/test_vanilla_django_backend.py
@@ -232,7 +232,24 @@ class TemplateBackendTestCase(MockedNetworkTestCaseMixin,
         self.assertEqual(message.bcc, ['bcc@example.com'])
         self.assertEqual(message.from_email, 'webmaster@localhost')
 
-    @override_settings(DEFAULT_FROM_EMAIL='default.email@localhost')
+    @override_settings(TEMPLATED_EMAIL_FROM_EMAIL='default.templated.email@localhost')
+    @patch.object(
+        template_backend_klass, '_render_email',
+        return_value={'plain': PLAIN_RESULT, 'subject': SUBJECT_RESULT}
+    )
+    def test_get_email_message_without_from_email_when_templated_email_from_email_is_set(self, mock):
+        message = self.backend.get_email_message(
+            'foo.email', cc=['cc@example.com'],
+            bcc=['bcc@example.com'], to=['to@example.com'])
+        self.assertTrue(isinstance(message, EmailMessage))
+        self.assertEqual(message.body, PLAIN_RESULT)
+        self.assertEqual(message.subject, SUBJECT_RESULT)
+        self.assertEqual(message.to, ['to@example.com'])
+        self.assertEqual(message.cc, ['cc@example.com'])
+        self.assertEqual(message.bcc, ['bcc@example.com'])
+        self.assertEqual(message.from_email, 'default.templated.email@localhost')
+
+    @override_settings(TEMPLATED_EMAIL_FROM_EMAIL='default.templated.email@localhost', DEFAULT_FROM_EMAIL='default.email@localhost')
     @patch.object(
         template_backend_klass, '_render_email',
         return_value={'plain': PLAIN_RESULT, 'subject': SUBJECT_RESULT}
@@ -247,7 +264,7 @@ class TemplateBackendTestCase(MockedNetworkTestCaseMixin,
         self.assertEqual(message.to, ['to@example.com'])
         self.assertEqual(message.cc, ['cc@example.com'])
         self.assertEqual(message.bcc, ['bcc@example.com'])
-        self.assertEqual(message.from_email, 'default.email@localhost')
+        self.assertEqual(message.from_email, 'default.templated.email@localhost')
 
     @patch.object(
         template_backend_klass, '_render_email',

--- a/tests/backends/test_vanilla_django_backend.py
+++ b/tests/backends/test_vanilla_django_backend.py
@@ -215,6 +215,55 @@ class TemplateBackendTestCase(MockedNetworkTestCaseMixin,
         self.assertEqual(message.cc, ['cc@example.com'])
         self.assertEqual(message.bcc, ['bcc@example.com'])
         self.assertEqual(message.from_email, 'from@example.com')
+    
+    @patch.object(
+        template_backend_klass, '_render_email',
+        return_value={'plain': PLAIN_RESULT, 'subject': SUBJECT_RESULT}
+    )
+    def test_get_email_message_without_from_email_when_no_default_email_is_set(self, mock):
+        message = self.backend.get_email_message(
+            'foo.email', cc=['cc@example.com'],
+            bcc=['bcc@example.com'], to=['to@example.com'])
+        self.assertTrue(isinstance(message, EmailMessage))
+        self.assertEqual(message.body, PLAIN_RESULT)
+        self.assertEqual(message.subject, SUBJECT_RESULT)
+        self.assertEqual(message.to, ['to@example.com'])
+        self.assertEqual(message.cc, ['cc@example.com'])
+        self.assertEqual(message.bcc, ['bcc@example.com'])
+        self.assertEqual(message.from_email, 'webmaster@localhost')
+
+    @override_settings(DEFAULT_FROM_EMAIL='default.email@localhost')
+    @patch.object(
+        template_backend_klass, '_render_email',
+        return_value={'plain': PLAIN_RESULT, 'subject': SUBJECT_RESULT}
+    )
+    def test_get_email_message_without_from_email_when_default_email_is_set(self, mock):
+        message = self.backend.get_email_message(
+            'foo.email', cc=['cc@example.com'],
+            bcc=['bcc@example.com'], to=['to@example.com'])
+        self.assertTrue(isinstance(message, EmailMessage))
+        self.assertEqual(message.body, PLAIN_RESULT)
+        self.assertEqual(message.subject, SUBJECT_RESULT)
+        self.assertEqual(message.to, ['to@example.com'])
+        self.assertEqual(message.cc, ['cc@example.com'])
+        self.assertEqual(message.bcc, ['bcc@example.com'])
+        self.assertEqual(message.from_email, 'default.email@localhost')
+
+    @patch.object(
+        template_backend_klass, '_render_email',
+        return_value={'plain': PLAIN_RESULT, 'subject': SUBJECT_RESULT}
+    )
+    def test_get_email_message_without_recipient_list(self, mock):
+        message = self.backend.get_email_message(
+            'foo.email',
+            from_email='from@example.com')
+        self.assertTrue(isinstance(message, EmailMessage))
+        self.assertEqual(message.body, PLAIN_RESULT)
+        self.assertEqual(message.subject, SUBJECT_RESULT)
+        self.assertEqual(message.to, [])
+        self.assertEqual(message.cc, [])
+        self.assertEqual(message.bcc, [])
+        self.assertEqual(message.from_email, 'from@example.com')
 
     @override_settings(TEMPLATED_EMAIL_DJANGO_SUBJECTS={'foo.email':
                                                         'foo\r\n'})

--- a/tests/backends/test_vanilla_django_backend.py
+++ b/tests/backends/test_vanilla_django_backend.py
@@ -137,7 +137,7 @@ class TemplateBackendTestCase(MockedNetworkTestCaseMixin,
     )
     def test_get_email_message(self, mock):
         message = self.backend.get_email_message(
-            'foo.email', {},
+            'foo.email',
             from_email='from@example.com', cc=['cc@example.com'],
             bcc=['bcc@example.com'], to=['to@example.com'])
         self.assertTrue(isinstance(message, EmailMessage))
@@ -155,7 +155,7 @@ class TemplateBackendTestCase(MockedNetworkTestCaseMixin,
     )
     def test_get_email_message_with_create_link(self, mocked):
         self.backend.get_email_message(
-            'foo.email', {},
+            'foo.email',
             from_email='from@example.com', cc=['cc@example.com'],
             bcc=['bcc@example.com'], to=['to@example.com'],
             create_link=True)
@@ -192,7 +192,7 @@ class TemplateBackendTestCase(MockedNetworkTestCaseMixin,
     )
     def test_custom_emailmessage_klass(self, mock):
         message = self.backend.get_email_message(
-            'foo.email', {},
+            'foo.email',
             from_email='from@example.com', cc=['cc@example.com'],
             bcc=['bcc@example.com'], to=['to@example.com'])
         self.assertTrue(isinstance(message, AnymailMessage))
@@ -205,7 +205,7 @@ class TemplateBackendTestCase(MockedNetworkTestCaseMixin,
     )
     def test_get_email_message_without_subject(self, mock):
         message = self.backend.get_email_message(
-            'foo.email', {},
+            'foo.email',
             from_email='from@example.com', cc=['cc@example.com'],
             bcc=['bcc@example.com'], to=['to@example.com'])
         self.assertTrue(isinstance(message, EmailMessage))
@@ -215,7 +215,7 @@ class TemplateBackendTestCase(MockedNetworkTestCaseMixin,
         self.assertEqual(message.cc, ['cc@example.com'])
         self.assertEqual(message.bcc, ['bcc@example.com'])
         self.assertEqual(message.from_email, 'from@example.com')
-    
+
     @patch.object(
         template_backend_klass, '_render_email',
         return_value={'plain': PLAIN_RESULT, 'subject': SUBJECT_RESULT}
@@ -273,7 +273,7 @@ class TemplateBackendTestCase(MockedNetworkTestCaseMixin,
     )
     def test_get_email_message_without_subject_multiple_templates(self, mock):
         message = self.backend.get_email_message(
-            ['woo.email', 'foo.email'], {},
+            ['woo.email', 'foo.email'],
             from_email='from@example.com', cc=['cc@example.com'],
             bcc=['bcc@example.com'], to=['to@example.com'])
         self.assertTrue(isinstance(message, EmailMessage))
@@ -290,7 +290,7 @@ class TemplateBackendTestCase(MockedNetworkTestCaseMixin,
     )
     def test_get_email_message_generated_plain_text(self, mock):
         message = self.backend.get_email_message(
-            'foo.email', {},
+            'foo.email',
             from_email='from@example.com', cc=['cc@example.com'],
             bcc=['bcc@example.com'], to=['to@example.com'])
         self.assertTrue(isinstance(message, EmailMultiAlternatives))
@@ -309,12 +309,12 @@ class TemplateBackendTestCase(MockedNetworkTestCaseMixin,
     )
     @override_settings(TEMPLATED_EMAIL_PLAIN_FUNCTION=lambda x: 'hi')
     def test_get_email_message_custom_func_generated_plain_text(self, mock):
-        message = self.backend.get_email_message('foo.email', {})
+        message = self.backend.get_email_message('foo.email')
         self.assertEqual(message.body, 'hi')
 
     def test_get_multi_match_last_email_message_generated_plain_text(self):
         message = self.backend.get_email_message(
-            ['multi-template.email', 'foo.email', ], {},
+            ['multi-template.email', 'foo.email', ],
             from_email='from@example.com', cc=['cc@example.com'],
             bcc=['bcc@example.com'], to=['to@example.com'])
         self.assertEqual(message.body, MULTI_TEMPLATE_PLAIN_RESULT)
@@ -326,7 +326,7 @@ class TemplateBackendTestCase(MockedNetworkTestCaseMixin,
 
     def test_get_multi_first_match_email_message_generated_plain_text(self):
         message = self.backend.get_email_message(
-            ['foo.email', 'multi-template.email', ], {},
+            ['foo.email', 'multi-template.email', ],
             from_email='from@example.com', cc=['cc@example.com'],
             bcc=['bcc@example.com'], to=['to@example.com'])
         self.assertEqual(message.body, MULTI_TEMPLATE_PLAIN_RESULT)
@@ -338,7 +338,7 @@ class TemplateBackendTestCase(MockedNetworkTestCaseMixin,
 
     def test_get_multi_options_select_last_plain_only(self):
         message = self.backend.get_email_message(
-            ['non-existing.email', 'also-non-existing.email', 'non-existing-without-suffix', 'foo.email', 'multi-template.email', ], {},
+            ['non-existing.email', 'also-non-existing.email', 'non-existing-without-suffix', 'foo.email', 'multi-template.email', ],
             from_email='from@example.com', cc=['cc@example.com'],
             bcc=['bcc@example.com'], to=['to@example.com'])
         self.assertEqual(message.body, MULTI_TEMPLATE_PLAIN_RESULT)
@@ -355,7 +355,7 @@ class TemplateBackendTestCase(MockedNetworkTestCaseMixin,
     )
     def test_get_email_message_with_plain_and_html(self, mock):
         message = self.backend.get_email_message(
-            'foo.email', {},
+            'foo.email',
             from_email='from@example.com', cc=['cc@example.com'],
             bcc=['bcc@example.com'], to=['to@example.com'])
         self.assertTrue(isinstance(message, EmailMultiAlternatives))
@@ -375,7 +375,7 @@ class TemplateBackendTestCase(MockedNetworkTestCaseMixin,
     def test_get_email_message_with_no_body_parts(self, mock):
         with pytest.raises(EmailRenderException):
             self.backend.get_email_message(
-                'foo.email', {},
+                'foo.email',
                 from_email='from@example.com', cc=['cc@example.com'],
                 bcc=['bcc@example.com'], to=['to@example.com'])
 
@@ -387,7 +387,7 @@ class TemplateBackendTestCase(MockedNetworkTestCaseMixin,
     )
     def test_custom_emailmessage_klass_multipart(self, mock):
         message = self.backend.get_email_message(
-            'foo.email', {},
+            'foo.email',
             from_email='from@example.com', cc=['cc@example.com'],
             bcc=['bcc@example.com'], to=['to@example.com'])
         self.assertTrue(isinstance(message, AnymailMessage))
@@ -400,7 +400,7 @@ class TemplateBackendTestCase(MockedNetworkTestCaseMixin,
     )
     def test_get_email_message_html_only(self, mock):
         message = self.backend.get_email_message(
-            'foo.email', {},
+            'foo.email',
             from_email='from@example.com', cc=['cc@example.com'],
             bcc=['bcc@example.com'], to=['to@example.com'])
         self.assertTrue(isinstance(message, EmailMessage))
@@ -419,7 +419,7 @@ class TemplateBackendTestCase(MockedNetworkTestCaseMixin,
     )
     def test_send(self, render_mock):
         ret = self.backend.send('mixed_template', 'from@example.com',
-                                ['to@example.com', 'to2@example.com'], {},
+                                ['to@example.com', 'to2@example.com'],
                                 headers={'Message-Id': 'a_message_id'})
         self.assertEqual(ret, 'a_message_id')
         self.assertEqual(len(mail.outbox), 1)
@@ -492,7 +492,7 @@ class TemplateBackendTestCase(MockedNetworkTestCaseMixin,
     )
     def test_send_attachment_mime_base(self, render_mock):
         self.backend.send('plain_template', 'from@example.com',
-                          ['to@example.com', 'to2@example.com'], {},
+                          ['to@example.com', 'to2@example.com'],
                           attachments=[MIMEImage(TXT_FILE, 'text/plain')])
         attachment = mail.outbox[0].attachments[0]
         self.assertEqual(decode_b64_msg(attachment.get_payload()),
@@ -505,7 +505,7 @@ class TemplateBackendTestCase(MockedNetworkTestCaseMixin,
     )
     def test_send_attachment_tripple(self, render_mock):
         self.backend.send('plain_template', 'from@example.com',
-                          ['to@example.com', 'to2@example.com'], {},
+                          ['to@example.com', 'to2@example.com'],
                           attachments=[('black_pixel.png', TXT_FILE, 'text/plain')])
         attachment = mail.outbox[0].attachments[0]
         self.assertEqual(('black_pixel.png', TXT_FILE, 'text/plain'),
@@ -517,7 +517,7 @@ class TemplateBackendTestCase(MockedNetworkTestCaseMixin,
     )
     def test_get_email_message_attachment_mime_base(self, mock):
         message = self.backend.get_email_message(
-            'foo.email', {},
+            'foo.email',
             from_email='from@example.com', cc=['cc@example.com'],
             bcc=['bcc@example.com'], to=['to@example.com'],
             attachments=[MIMEImage(TXT_FILE, 'text/plain')])
@@ -531,7 +531,7 @@ class TemplateBackendTestCase(MockedNetworkTestCaseMixin,
     )
     def test_get_email_message_attachment_tripple(self, mock):
         message = self.backend.get_email_message(
-            'foo.email', {},
+            'foo.email',
             from_email='from@example.com', cc=['cc@example.com'],
             bcc=['bcc@example.com'], to=['to@example.com'],
             attachments=[('black_pixel.png', TXT_FILE, 'text/plain')])

--- a/tests/generic_views/test_views.py
+++ b/tests/generic_views/test_views.py
@@ -134,10 +134,27 @@ class TemplatedEmailFormViewMixinTestCase(MockedNetworkTestCaseMixin, TestCase):
         AuthorCreateView.templated_email_send_on_failure = default_value
 
     @override_settings(TEMPLATED_EMAIL_FROM_EMAIL='from@vinta.com.br')
-    def test_from_email(self):
+    def test_from_email_with_templated_email_from_email_setting(self):
         AuthorCreateView.as_view()(self.good_request)
         self.assertEqual(len(mail.outbox), 1)
         self.assertEqual(mail.outbox[0].from_email, 'from@vinta.com.br')
+
+    @override_settings(DEFAULT_FROM_EMAIL='default@vinta.com.br')
+    def test_from_email_with_default_django_from_email_setting(self):
+        AuthorCreateView.as_view()(self.good_request)
+        self.assertEqual(len(mail.outbox), 1)
+        self.assertEqual(mail.outbox[0].from_email, 'default@vinta.com.br')
+
+    @override_settings(TEMPLATED_EMAIL_FROM_EMAIL='from@vinta.com.br', DEFAULT_FROM_EMAIL='default@vinta.com.br')
+    def test_from_email_with_both_templated_mail_and_default_django_from_email_settings(self):
+        AuthorCreateView.as_view()(self.good_request)
+        self.assertEqual(len(mail.outbox), 1)
+        self.assertEqual(mail.outbox[0].from_email, 'from@vinta.com.br')
+
+    def test_from_email_default(self):
+        AuthorCreateView.as_view()(self.good_request)
+        self.assertEqual(len(mail.outbox), 1)
+        self.assertEqual(mail.outbox[0].from_email, 'webmaster@localhost')
 
     def test_from_email_with_templated_email_from_email(self):
         default_value = AuthorCreateView.templated_email_from_email


### PR DESCRIPTION
Resolves #97

The `context` and `recipient_list`params also had to be set as `default=None` otherwise it wouldn't be possible to set `from_email=None`.

It doesn't change the order of the params, so it's not a breaking change.

It also removes the empty context params **{}** which are not required anymore.