### PR TITLE
Remove all newlines from subject

### DIFF
--- a/templated_email/backends/vanilla_django.py
+++ b/templated_email/backends/vanilla_django.py
@@ -158,7 +158,7 @@ class TemplateBackend(object):
                 subject_template = subject_dict.get(template_name,
                                                     _('%s email subject' % template_name))
             subject = subject_template % context
-        subject = subject.strip('\n\r')  # strip newlines from subject
+        subject = subject.strip('\n\r').replace('\n', ' ').replace('\r', ' ')  # strip newlines from subject
 
         if not plain_part:
             plain_part = self._generate_plain_part(parts)


### PR DESCRIPTION
Django doesn't allow newlines at all in the subject, not just at the start or end.

This is useful if the template generates the subject based on context variables which may have newlines in them.